### PR TITLE
use cross-platform version of /dev/null

### DIFF
--- a/gofer/notebook.py
+++ b/gofer/notebook.py
@@ -2,6 +2,7 @@ from contextlib import redirect_stderr, redirect_stdout
 import inspect
 from .utils import hide_outputs
 import ast
+import os
 
 try:
     from IPython.core.inputsplitter import IPythonInputSplitter
@@ -142,7 +143,7 @@ def execute_notebook(nb, secret='secret', initial_env=None, ignore_errors=False)
 
         cleaned_source = compile(tree, filename="nb-ast", mode="exec")
         try:
-            with open('/dev/null', 'w') as f, redirect_stdout(f), redirect_stderr(f):
+            with open(os.devnull, 'w') as f, redirect_stdout(f), redirect_stderr(f):
                 exec(cleaned_source, global_env)
         except:
             if not ignore_errors:

--- a/gofer/ok.py
+++ b/gofer/ok.py
@@ -4,6 +4,7 @@ import io
 import itertools
 import json
 import glob
+import os
 import random
 import string
 from contextlib import redirect_stderr, redirect_stdout
@@ -43,7 +44,7 @@ def run_doctest(name, doctest_string, global_environment):
     runresults = io.StringIO()
     with redirect_stdout(runresults), redirect_stderr(runresults), hide_outputs():
         doctestrunner.run(test, clear_globs=False)
-    with open('/dev/null', 'w') as f, redirect_stderr(f), redirect_stdout(f):
+    with open(os.devnull, 'w') as f, redirect_stderr(f), redirect_stdout(f):
         result = doctestrunner.summarize(verbose=True)
     # An individual test can only pass or fail
     if result.failed == 0:


### PR DESCRIPTION
`/dev/null` doesn't exist on the Windows operating system but there's an equivalent file.  Gofer consequently raises an error on Windows.  Python hides this difference under the cross-platform code `os.devnull`.  This PR updates usages of `/dev/null` to `os.devnull`, which is compatible with all operating systems.