### PR TITLE
MRG: refactor to allow return of test results

### DIFF
--- a/gofer/ok.py
+++ b/gofer/ok.py
@@ -135,15 +135,17 @@ class OKTest:
 
 
 class OKTests:
-    def __init__(self, test_paths):
+    def __init__(self, test_paths, cwd=None):
         self.paths = test_paths
         self.tests = [OKTest.from_file(path) for path in self.paths]
+        self.cwd = cwd if cwd else os.getcwd()
 
     def run(self, global_environment, include_grade=True):
         passed_tests = []
         failed_tests = []
         for t in self.tests:
-            passed, hint = t.run(global_environment)
+            with cd(self.cwd):
+                passed, hint = t.run(global_environment)
             if passed:
                 passed_tests.append(t)
             else:
@@ -273,7 +275,7 @@ def grade_notebook(notebook_path, tests_glob=None):
     return score
 
 
-def check(test_file_path, global_env=None):
+def check(test_file_path, global_env=None, cwd=None):
     """
     check global_env against given test_file in oktest format
 
@@ -286,7 +288,7 @@ def check(test_file_path, global_env=None):
 
     Returns a TestResult object.
     """
-    tests = OKTests([test_file_path])
+    tests = OKTests([test_file_path], cwd=cwd)
 
     if global_env is None:
         # Get the global env of our callers - one level below us in the stack

--- a/gofer/utils.py
+++ b/gofer/utils.py
@@ -1,6 +1,9 @@
+import os
 import sys
 from contextlib import contextmanager
+
 from IPython import get_ipython
+
 
 def flush_inline_matplotlib_plots():
     """
@@ -47,3 +50,15 @@ def hide_outputs():
     finally:
         flush_inline_matplotlib_plots()
         ipy.display_formatter.formatters = old_formatters
+
+
+@contextmanager
+def cd(newdir):
+    """ Context manager to change working directory
+    """
+    prevdir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)

--- a/tests/notebooks/pwd/extra_tests/has_var.py
+++ b/tests/notebooks/pwd/extra_tests/has_var.py
@@ -1,0 +1,22 @@
+test = {
+  'name': 'Presence of variable',
+  'points': 1,
+  'suites': [
+    {
+      'cases': [
+        {
+          'code': r"""
+          >>> 'extra_variable' in vars()
+          True
+          """,
+          'hidden': False,
+          'locked': False
+        },
+      ],
+      'scored': True,
+      'setup': '',
+      'teardown': '',
+      'type': 'doctest'
+    }
+  ]
+}

--- a/tests/notebooks/pwd/pwd.ipynb
+++ b/tests/notebooks/pwd/pwd.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from client.api.notebook import Notebook\n",
+    "ok = Notebook('pwd.ok')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_variable = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Just tests if \"my_variable\" is defined.\n",
+    "ok.grade('q1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate an error, to test ignoring errors in notebook execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1/0"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "split_at_heading": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/pwd/tests/q1.py
+++ b/tests/notebooks/pwd/tests/q1.py
@@ -1,0 +1,23 @@
+test = {
+  'name': '',
+  'points': 1,
+  'suites': [
+    {
+      'cases': [
+        {
+          'code': r"""
+          >>> import os
+          >>> os.path.isfile('pwd.ipynb')
+          True
+          """,
+          'hidden': False,
+          'locked': False
+        },
+      ],
+      'scored': True,
+      'setup': '',
+      'teardown': '',
+      'type': 'doctest'
+    }
+  ]
+}

--- a/tests/test_nb.py
+++ b/tests/test_nb.py
@@ -1,9 +1,15 @@
 import os
+import os.path as op
 import json
 import pytest
 from glob import glob
-from gofer.ok import grade_notebook
+
+import nbformat
+
+from gofer.ok import grade_notebook, run_nb_tests
 from gofer.notebook import execute_notebook, _global_anywhere
+
+import pytest
 
 here = os.path.dirname(__file__)
 
@@ -102,3 +108,42 @@ def test_grade_notebook():
 
     zero_grade_notebook = os.path.join(here, 'notebooks/grading/zero-grade.ipynb')
     assert grade_notebook(zero_grade_notebook, glob(test_paths)) == 0
+
+
+def test_nb_wd():
+    # Test that notebook runs in its own directory.
+    # Test will fail, give 0 score if notebook does not run in own directory.
+    test_paths = os.path.join(here, 'notebooks', 'pwd', 'tests', 'q*.py')
+    pwd_notebook = os.path.join(here, 'notebooks', 'pwd', 'pwd.ipynb')
+    assert grade_notebook(pwd_notebook, glob(test_paths)) == 1
+
+
+def test_run_nb_tests():
+    # Test API for run_nb_tests
+    # Test will fail, give 0 score, if notebook does not run in own directory.
+    pwd_path = op.join(here, 'notebooks', 'pwd')
+    test_paths = op.join(pwd_path, 'tests', 'q*.py')
+    tests = glob(test_paths)
+    pwd_notebook = op.join(pwd_path, 'pwd.ipynb')
+    nb = nbformat.read(pwd_notebook, nbformat.NO_CONVERT)
+    test_results = run_nb_tests(nb, pwd_path, tests)
+    assert len(test_results) == 1
+    assert test_results[0].grade == 1
+    # When the directory is incorrect, the test fails.
+    test_results = run_nb_tests(nb, here, tests)
+    assert test_results[0].grade == 0
+    # We can add variables to the environment with initial_env
+    env_test = op.join(pwd_path, 'extra_tests', 'has_var.py')
+    # Fails without initial var.
+    test_results = run_nb_tests(nb, pwd_path, [env_test])
+    assert test_results[0].grade == 0
+    # Passes with.
+    test_results = run_nb_tests(nb, pwd_path, [env_test],
+                                initial_env={'extra_variable': 1}
+                               )
+    assert test_results[0].grade == 1
+    # The test notebook also has a cell causing an error.
+    # By default, testing ignores the error.  With ignore_errors=False, the
+    # error falls through to us.
+    with pytest.raises(ZeroDivisionError):
+        test_results = run_nb_tests(nb, pwd_path, tests, ignore_errors=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+""" Tests for utils module
+"""
+
+import os
+import os.path as op
+from tempfile import TemporaryDirectory
+
+from gofer.utils import cd
+
+
+def test_cd():
+    # Test InGivenDirectory
+    cwd = op.realpath(os.getcwd())
+    with TemporaryDirectory() as tmpdir:
+        # Ok, it's paranoid, but just in case
+        tmp_path = op.realpath(tmpdir)
+        assert cwd == op.realpath(os.getcwd())
+        assert tmp_path != cwd
+        with cd(tmpdir):
+            assert tmp_path == op.realpath(os.getcwd())
+        assert cwd == op.realpath(os.getcwd())


### PR DESCRIPTION
Break up testing function to allow return of individual test results.

Is this a reasonable way to go?

I'm making a command line interface, and I want to give a report for all the
tests, with their test failures.