### PR TITLE
NF+TST: add setup and teardown

### DIFF
--- a/gofer/ok.py
+++ b/gofer/ok.py
@@ -122,14 +122,16 @@ class OKTest:
         # Only support doctest. I am unsure if other tests are implemented
         assert test_suite.get('type', 'doctest') == 'doctest'
 
-        # Not setup and teardown supported
-        assert not bool(test_suite.get('setup'))
-        assert not bool(test_suite.get('teardown'))
+        # setup and teardown supported
+        setup = test_suite.get('setup')
+        teardown = test_suite.get('teardown')
 
         tests = []
 
         for i, test_case in enumerate(test_spec['suites'][0]['cases']):
-            tests.append(dedent(test_case['code']))
+            code_parts = [setup, test_case['code'], teardown]
+            code = '\n'.join(dedent(p) for p in code_parts if p)
+            tests.append(code)
 
         return cls(path, tests)
 

--- a/tests/notebooks/grading/extra_tests/import_example.py
+++ b/tests/notebooks/grading/extra_tests/import_example.py
@@ -1,0 +1,24 @@
+test = {
+  'name': '',
+  'points': 1,
+  'suites': [
+    {
+      'cases': [
+        {
+          'code': r"""
+          >>> np.sqrt(1)
+          1.0
+          """,
+          'hidden': False,
+          'locked': False
+        },
+      ],
+      'scored': True,
+      'setup': r"""
+      >>> import numpy as np
+      """,
+      'teardown': '',
+      'type': 'doctest'
+    }
+  ]
+}

--- a/tests/notebooks/grading/extra_tests/setup_example.py
+++ b/tests/notebooks/grading/extra_tests/setup_example.py
@@ -1,0 +1,24 @@
+test = {
+  'name': '',
+  'points': 1,
+  'suites': [
+    {
+      'cases': [
+        {
+          'code': r"""
+          >>> setup_var
+          665.99
+          """,
+          'hidden': False,
+          'locked': False
+        },
+      ],
+      'scored': True,
+      'setup': r"""
+      >>> setup_var = 665.99
+      """,
+      'teardown': '',
+      'type': 'doctest'
+    }
+  ]
+}

--- a/tests/notebooks/grading/extra_tests/setup_teardown_example.py
+++ b/tests/notebooks/grading/extra_tests/setup_teardown_example.py
@@ -1,0 +1,26 @@
+test = {
+  'name': '',
+  'points': 1,
+  'suites': [
+    {
+      'cases': [
+        {
+          'code': r"""
+          >>> np.sqrt(1)
+          1.0
+          """,
+          'hidden': False,
+          'locked': False
+        },
+      ],
+      'scored': True,
+      'setup': r"""
+      >>> import numpy as np
+      """,
+      'teardown': r"""
+      >>> assert False
+      """,
+      'type': 'doctest'
+    }
+  ]
+}

--- a/tests/test_nb.py
+++ b/tests/test_nb.py
@@ -1,4 +1,5 @@
 import os
+import os.path as op
 import json
 import pytest
 from glob import glob
@@ -102,3 +103,16 @@ def test_grade_notebook():
 
     zero_grade_notebook = os.path.join(here, 'notebooks/grading/zero-grade.ipynb')
     assert grade_notebook(zero_grade_notebook, glob(test_paths)) == 0
+
+
+def test_setup_teardown():
+    gnb_path = op.join(here, 'notebooks', 'grading')
+    extra_path = op.join(gnb_path, 'extra_tests')
+    setup_test = op.join(extra_path, 'setup_example.py')
+    full_grade_notebook = op.join(gnb_path, 'full-grade.ipynb')
+    assert grade_notebook(full_grade_notebook, [setup_test]) == 1
+    import_test = op.join(extra_path, 'import_example.py')
+    assert grade_notebook(full_grade_notebook, [import_test]) == 1
+    setup_td_test = op.join(extra_path, 'setup_teardown_example.py')
+    # The assert in the teardown generates a failure.
+    assert grade_notebook(full_grade_notebook, [setup_td_test]) == 0


### PR DESCRIPTION
Add setup, teardown by prefixing, suffixing to test code.

Closes #25.